### PR TITLE
chore: Update speakeasy_sdk_generation.yml to only retain stackone and hris OAS

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -24,9 +24,6 @@ jobs:
       openapi_docs: |
         - https://api2.eu1.stackone.com/oas/stackone.json
         - https://api2.eu1.stackone.com/oas/hris.json
-        - https://api2.eu1.stackone.com/oas/ats.json
-        - https://api2.eu1.stackone.com/oas/crm.json
-        - https://api2.eu1.stackone.com/oas/marketing.json
       publish_ruby: true
       speakeasy_version: latest
     secrets:


### PR DESCRIPTION
This is the current errors flagged when running the gem

```
/Users/guillaume/.rvm/gems/ruby-3.2.2/gems/stackone_client-0.0.3/lib/stackone/models/shared/atscreateapplicationrequestdto.rb:77:in `<class:AtsCreateApplicationRequestDto>': uninitialized constant StackOne::Shared::ApplicationAttachment (NameError)

      field :attachments, T.nilable(T::Array[Shared::ApplicationAttachment]), { 'format_json': { 'letter_case': ::StackOne::Utils.field_name('attachments') } }
                                                   ^^^^^^^^^^^^^^^^^^^^^^^
	from /Users/guillaume/.rvm/gems/ruby-3.2.2/gems/stackone_client-0.0.3/lib/stackone/models/shared/atscreateapplicationrequestdto.rb:71:in `<module:Shared>'
	from /Users/guillaume/.rvm/gems/ruby-3.2.2/gems/stackone_client-0.0.3/lib/stackone/models/shared/atscreateapplicationrequestdto.rb:10:in `<module:StackOne>'
	from /Users/guillaume/.rvm/gems/ruby-3.2.2/gems/stackone_client-0.0.3/lib/stackone/models/shared/atscreateapplicationrequestdto.rb:9:in `<top (required)>'
	from /Users/guillaume/.rvm/gems/ruby-3.2.2/gems/stackone_client-0.0.3/lib/stackone_client.rb:18:in `require_relative'
	from /Users/guillaume/.rvm/gems/ruby-3.2.2/gems/stackone_client-0.0.3/lib/stackone_client.rb:18:in `<top (required)>'
	from <internal:/Users/guillaume/.rvm/rubies/ruby-3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from <internal:/Users/guillaume/.rvm/rubies/ruby-3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from main.rb:1:in `<main>'
```

Although it's unsure if there would still be errors in the HRIS model, removing currently superfluous open api spec may help get the new ruby client up and running if only for HRIS use-cases