### PR TITLE
Revert "chore: Update speakeasy_sdk_generation.yml to only retain stackone and hris OAS"

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -24,6 +24,9 @@ jobs:
       openapi_docs: |
         - https://api2.eu1.stackone.com/oas/stackone.json
         - https://api2.eu1.stackone.com/oas/hris.json
+        - https://api2.eu1.stackone.com/oas/ats.json
+        - https://api2.eu1.stackone.com/oas/crm.json
+        - https://api2.eu1.stackone.com/oas/marketing.json
       publish_ruby: true
       speakeasy_version: latest
     secrets:


### PR DESCRIPTION
Reverts StackOneHQ/stackone-client-ruby#13