### PR TITLE
Pinning GitHub actions

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -19,7 +19,7 @@ permissions:
         - cron: 0 9 * * 1
 jobs:
     generate:
-        uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
+        uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@3fdab59e74dda7831d7401f7aa1bb55d706913d7 # v15
         with:
             force: ${{ github.event.inputs.force }}
             mode: pr

--- a/.github/workflows/speakeasy_sdk_publish.yml
+++ b/.github/workflows/speakeasy_sdk_publish.yml
@@ -7,7 +7,7 @@ name: Publish
             - RELEASES.md
 jobs:
     publish:
-        uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15
+        uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@3fdab59e74dda7831d7401f7aa1bb55d706913d7 # v15
         secrets:
             github_access_token: ${{ secrets.GITHUB_TOKEN }}
             rubygems_auth_token: ${{ secrets.RUBYGEMS_AUTH_TOKEN }}

--- a/.github/workflows/tagging.yaml
+++ b/.github/workflows/tagging.yaml
@@ -12,7 +12,7 @@ permissions:
     workflow_dispatch: {}
 jobs:
     tag:
-        uses: speakeasy-api/sdk-generation-action/.github/workflows/tag.yaml@v15
+        uses: speakeasy-api/sdk-generation-action/.github/workflows/tag.yaml@3fdab59e74dda7831d7401f7aa1bb55d706913d7 # v15
         with:
             registry_tags: main
         secrets:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pinned Speakeasy GitHub Action workflows to an immutable v15 reference to meet ENG-11298 and ensure reproducible, secure runs.
Applies to the SDK generation, publish, and tagging workflows.

<sup>Written for commit 618072bf4d124010e549029261d8f4a0519e8368. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

