### PR TITLE
added in genignore and readded hook types from speakeasy recommendation

### DIFF
--- a/lib/.genignore
+++ b/lib/.genignore
@@ -1,0 +1,1 @@
+lib/stack_one/sdk_hooks/hooks.rb

--- a/lib/stack_one/sdk_hooks/hooks.rb
+++ b/lib/stack_one/sdk_hooks/hooks.rb
@@ -3,6 +3,8 @@
 # typed: true
 # frozen_string_literal: true
 
+require_relative './types'
+
 module StackOne
   module SDKHooks
     class Hooks


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Exclude the Hooks file from code generation and restore hook types per Speakeasy guidance. Added lib/.genignore to ignore lib/stack_one/sdk_hooks/hooks.rb, and require_relative './types' in hooks.rb to load types and prevent generator overwrites.

<sup>Written for commit 0fb87b6b15595f36938ad7ea1f36dae375ba679c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

