### PR TITLE
fix:added additional overlay for handling integer

### DIFF
--- a/.speakeasy/ruby-modifications-overlay.yaml
+++ b/.speakeasy/ruby-modifications-overlay.yaml
@@ -9,4 +9,10 @@ actions:
         - integer
         - number
 
+  - target: "$.components.schemas.AssignmentStatusEnum.properties.source_value.oneOf[?(@.type=='number')]"
+    update:
+      type:
+        - integer
+        - number
+
 


### PR DESCRIPTION
Fuse reported a type error for list_assignments_status. The provider was returning an integer which isn't handled in the ruby sdk by default. I added a config for handling this.