### PR TITLE
Updated overlay syntax fixing generate error

### DIFF
--- a/.speakeasy/ruby-modifications-overlay.yaml
+++ b/.speakeasy/ruby-modifications-overlay.yaml
@@ -9,4 +9,10 @@ actions:
         - integer
         - number
 
+  - target: "$.components.schemas.AssignmentStatusEnum.properties.source_value.oneOf[?(@.type=='number')]"
+    update:
+      type:
+        - integer
+        - number
+
 

--- a/.speakeasy/ruby-modifications-overlay.yaml
+++ b/.speakeasy/ruby-modifications-overlay.yaml
@@ -12,11 +12,3 @@ actions:
     description: Add integer type option to allow Ruby SDK to accept integer values
     update:
       - type: integer
-
-  - target: "$.components.schemas.AssignmentStatusEnum.properties.source_value.oneOf[?(@.type=='number')]"
-    update:
-      type:
-        - integer
-        - number
-
-

--- a/.speakeasy/ruby-modifications-overlay.yaml
+++ b/.speakeasy/ruby-modifications-overlay.yaml
@@ -3,16 +3,14 @@ info:
   title: Fix Number Types
   version: 1.0.0
 actions:
-  - target: "$.components.schemas.EmploymentStatusEnum.properties.source_value.oneOf[?(@.type=='number')]"
+  - target: "$.components.schemas.EmploymentStatusEnum.properties.source_value.oneOf"
+    description: Add integer type option to allow Ruby SDK to accept integer values
     update:
-      type:
-        - integer
-        - number
+      - type: integer
 
-  - target: "$.components.schemas.AssignmentStatusEnum.properties.source_value.oneOf[?(@.type=='number')]"
+  - target: "$.components.schemas.AssignmentStatusEnum.properties.source_value.oneOf"
+    description: Add integer type option to allow Ruby SDK to accept integer values
     update:
-      type:
-        - integer
-        - number
+      - type: integer
 
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `type: integer` to `source_value.oneOf` for `EmploymentStatusEnum` and `AssignmentStatusEnum` in the Ruby overlay, and remove unused config. Fixes Ruby SDK generation errors and allows integer `source_value` values.

<sup>Written for commit 6958d83199426352b32c792d20e81c6d9df3042b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

