### PR TITLE
Updated overlay syntax fixing generate error

### DIFF
--- a/.speakeasy/ruby-modifications-overlay.yaml
+++ b/.speakeasy/ruby-modifications-overlay.yaml
@@ -9,4 +9,10 @@ actions:
         - integer
         - number
 
+  - target: "$.components.schemas.AssignmentStatusEnum.properties.source_value.oneOf[?(@.type=='number')]"
+    update:
+      type:
+        - integer
+        - number
+
 

--- a/.speakeasy/ruby-modifications-overlay.yaml
+++ b/.speakeasy/ruby-modifications-overlay.yaml
@@ -12,11 +12,3 @@ actions:
     description: Add integer type option to allow Ruby SDK to accept integer values
     update:
       - type: integer
-
-  - target: "$.components.schemas.AssignmentStatusEnum.properties.source_value.oneOf[?(@.type=='number')]"
-    update:
-      type:
-        - integer
-        - number
-
-

--- a/.speakeasy/ruby-modifications-overlay.yaml
+++ b/.speakeasy/ruby-modifications-overlay.yaml
@@ -3,16 +3,14 @@ info:
   title: Fix Number Types
   version: 1.0.0
 actions:
-  - target: "$.components.schemas.EmploymentStatusEnum.properties.source_value.oneOf[?(@.type=='number')]"
+  - target: "$.components.schemas.EmploymentStatusEnum.properties.source_value.oneOf"
+    description: Add integer type option to allow Ruby SDK to accept integer values
     update:
-      type:
-        - integer
-        - number
+      - type: integer
 
-  - target: "$.components.schemas.AssignmentStatusEnum.properties.source_value.oneOf[?(@.type=='number')]"
+  - target: "$.components.schemas.AssignmentStatusEnum.properties.source_value.oneOf"
+    description: Add integer type option to allow Ruby SDK to accept integer values
     update:
-      type:
-        - integer
-        - number
+      - type: integer
 
 

--- a/.speakeasy/ruby-modifications-overlay.yaml
+++ b/.speakeasy/ruby-modifications-overlay.yaml
@@ -19,4 +19,11 @@ actions:
       ActionsRpcResponse:
         type: object
         description: Direct RPC response from an action execution
+        properties:
+          data:
+            description: Payload returned from the action execution
+            nullable: true
+          next:
+            description: Continuation token or next-page reference returned from the action execution
+            nullable: true
         additionalProperties: true

--- a/.speakeasy/ruby-modifications-overlay.yaml
+++ b/.speakeasy/ruby-modifications-overlay.yaml
@@ -1,6 +1,6 @@
 overlay: 1.0.0
 info:
-  title: Fix Number Types
+  title: Fix Number Types and Missing Schemas
   version: 1.0.0
 actions:
   - target: "$.components.schemas.EmploymentStatusEnum.properties.source_value.oneOf"
@@ -12,3 +12,11 @@ actions:
     description: Add integer type option to allow Ruby SDK to accept integer values
     update:
       - type: integer
+
+  - target: "$.components.schemas"
+    description: Add missing ActionsRpcResponse schema definition
+    update:
+      ActionsRpcResponse:
+        type: object
+        description: Direct RPC response from an action execution
+        additionalProperties: true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes SDK generation errors by updating `.speakeasy/ruby-modifications-overlay.yaml`. Allows integer values for `EmploymentStatusEnum.source_value` and defines the missing `ActionsRpcResponse` schema (object with optional `data`, `next`, and `additionalProperties: true`) referenced by `/actions/rpc`.

<sup>Written for commit adf4a89709675b21c2ffb2d0295c1f48b303e246. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

