### PR TITLE
fix: resolve dangling StepLogPartial $ref breaking SDK generation

### DIFF
--- a/.speakeasy/ruby-modifications-overlay.yaml
+++ b/.speakeasy/ruby-modifications-overlay.yaml
@@ -13,6 +13,13 @@ actions:
     update:
       - type: integer
 
+  - target: "$.components.schemas.UnifiedLogsPartialLegacy.properties.step_requests.items"
+    description: >-
+      Retarget dangling $ref. Upstream renamed StepLogPartial -> StepLogPartialLegacy
+      but missed this reference, leaving it unresolvable.
+    update:
+      $ref: "#/components/schemas/StepLogPartialLegacy"
+
   - target: "$.components.schemas"
     description: Add missing ActionsRpcResponse schema definition
     update:


### PR DESCRIPTION
## Problem

SDK generation is failing at the **Validating Document** step:

```
ERROR validation error: [line 67901:2886] resolution-json-schema - not found
  -- key StepLogPartial not found in sequencedmap.Map
```

In `https://api.eu1.stackone.com/oas/stackone.json`:

```
components.schemas.UnifiedLogsPartialLegacy.properties.step_requests.items
  → $ref: "#/components/schemas/StepLogPartial"   ← not defined anywhere
```

Upstream renamed that schema to `StepLogPartialLegacy` and missed this one reference.

## Evidence for the rename

Not a guess. The property set in the previously-generated `stackone-client-typescript` `StepLogPartial` model — `request_id`, `start_time`, `end_time`, `account_id`, `project_id`, `http_method`, `path`, `url`, `status`, `duration`, `success`, `provider`, `service`, `resource`, `child_resource`, `sub_resource`, `action`, `is_worker`, `id` — is an exact match for today's `StepLogPartialLegacy`.

## Fix

Retargets the `$ref` via overlay, following the existing `ActionsRpcResponse` workaround already in this file (same class of bug, same file).

## Verification

`speakeasy run` locally (v1.638.0): validation passes, **SDK generated successfully ✓**. The run only fails afterwards at *Snapshotting Code Samples* on a local auth-org mismatch (`s1` vs `stackone`), unrelated to the spec.

## Follow-up (not in this PR)

This is a band-aid. The dangling ref is in the OAS producer (`unified-cloud-api`), so **every** SDK consuming this spec has the same broken ref. Worth fixing the `UnifiedLogsPartialLegacy` DTO at source and then dropping both overlay workarounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)