### PR TITLE
fix: tolerate missing created_at/updated_at in LinkedAccount responses

### DIFF
--- a/.speakeasy/ruby-modifications-overlay.yaml
+++ b/.speakeasy/ruby-modifications-overlay.yaml
@@ -20,6 +20,36 @@ actions:
     update:
       $ref: "#/components/schemas/StepLogPartialLegacy"
 
+  # The live GET /accounts response omits created_at/updated_at for some providers
+  # (e.g. linkedin_lms), but the spec marks them required + non-nullable. Crystalline's
+  # strict from_dict then raises KeyError on the missing key, and because the /accounts
+  # 200 oneOf branches both wrap LinkedAccount, the whole paginated response fails to
+  # deserialize (returns nil). Make the two timestamps nullable AND drop them from
+  # required so the generated model tolerates their absence.
+  - target: "$.components.schemas.LinkedAccount.properties.created_at"
+    description: Allow created_at to be absent/null in LinkedAccount responses
+    update:
+      nullable: true
+
+  - target: "$.components.schemas.LinkedAccount.properties.updated_at"
+    description: Allow updated_at to be absent/null in LinkedAccount responses
+    update:
+      nullable: true
+
+  - target: "$.components.schemas.LinkedAccount.required"
+    description: Remove created_at/updated_at from required (API omits them for some providers)
+    remove: true
+
+  - target: "$.components.schemas.LinkedAccount"
+    description: Re-add LinkedAccount.required without the two optional timestamps
+    update:
+      required:
+        - id
+        - provider
+        - status
+        - origin_owner_id
+        - origin_owner_name
+
   - target: "$.components.schemas"
     description: Add missing ActionsRpcResponse schema definition
     update:


### PR DESCRIPTION
## Problem

`accounts.list_linked_accounts` (GET `/accounts`) fails to deserialize on **every** call for some providers. Reported against 0.40.1; still broken on 0.41.0 (fails differently — see below).

Root cause is a spec-vs-reality mismatch on the nested `LinkedAccount`:

- The spec marks `created_at` and `updated_at` as **required + non-nullable**.
- The live API **omits** them for some providers (the bug report's `linkedin_lms` example has neither).

Crystalline's strict `from_dict` raises `KeyError: key created_at not found in hash` while building each nested `LinkedAccount`. The `/accounts` 200 response is a `oneOf` whose branches **both** wrap `LinkedAccount`, so both fail and the whole page is lost over two absent timestamps on one record:

| | 0.40.1 | 0.41.0 |
|---|---|---|
| Unmarshal target | bare `Array<LinkedAccount>` | `Union<LinkedAccountsPaginated, Array<LinkedAccount>>` |
| Failure | `TypeError` raised | returns `nil` silently |

Evidence the report's example is a **real capture, not trimmed**: it includes a `metadata` field that isn't in the OpenAPI schema at all.

## Fix

Overlay actions that make `created_at`/`updated_at` `nullable` **and** drop them from `LinkedAccount.required`, so the generated model deserializes accounts that lack them. (Both changes are needed: nullable alone leaves them keyword-required in the constructor → `ArgumentError`.)

## Verification

Regenerated locally (speakeasy 1.638.0, lint **0 errors**, SDK generated successfully) and deserialized:

- the **exact** payload from the bug report (timestamps absent) → `LinkedAccountsPaginated`, `data.size=1`, timestamps `nil` ✓
- a full payload **with** timestamps → parses them correctly ✓
- the bare-array `oneOf` branch → `Array<LinkedAccount>` ✓

## Follow-up (not in this PR)

Stopgap in the Ruby overlay. The real fix belongs in the OAS producer (`unified-cloud-api`): either always return `created_at`/`updated_at`, or mark them nullable there — that covers the TS and PHP SDKs too, which have the same latent break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)